### PR TITLE
JavaScript capitalisation fix and fix for html5shiv.js

### DIFF
--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -6,11 +6,11 @@
     <title>JSCompress: Minify Javascript Online / Online JavaScript Compression</title>
 
     <meta name="keywords" content="javascript compressor, compress javascript, minify javascript, minify js online, online javascript packer, js packer tool, online jsmin, uglify js">
-    <meta name="description" content="Free online instant javascript compression tool. Copy and paste your code in or upload multiple files to combine them together.">
+    <meta name="description" content="Free online instant JavaScript compression tool. Copy and paste your code in or upload multiple files to combine them together.">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <!--[if lt IE 9]>
-        <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+        <script src="https://cdn.jsdelivr.net/html5shiv/3.7.3/html5shiv.min.js"></script>
     <![endif]-->
     <link type="text/css" href="/stylesheets/pure-min.css" rel="stylesheet" />
     <link type="text/css" href="/stylesheets/styles.css" rel="stylesheet" />


### PR DESCRIPTION
html5shiv.js link was broken.
JavaScript capitalisation fix in description